### PR TITLE
feat(warmup): both support CR name and cache-group name

### DIFF
--- a/api/v1/warmup_types.go
+++ b/api/v1/warmup_types.go
@@ -75,6 +75,7 @@ type Cron struct {
 // WarmUpStatus defines the observed state of WarmUp
 type WarmUpStatus struct {
 	Phase      WarmUpPhase `json:"phase"`
+	CacheGroup string      `json:"cacheGroup,omitempty"`
 	Duration   string      `json:"duration,omitempty"`
 	Conditions []Condition `json:"conditions,omitempty"`
 

--- a/config/crd/bases/juicefs.io_warmups.yaml
+++ b/config/crd/bases/juicefs.io_warmups.yaml
@@ -140,6 +140,8 @@ spec:
             properties:
               LastCompleteNode:
                 type: string
+              cacheGroup:
+                type: string
               conditions:
                 items:
                   properties:

--- a/dist/crd.yaml
+++ b/dist/crd.yaml
@@ -7161,6 +7161,8 @@ spec:
             properties:
               LastCompleteNode:
                 type: string
+              cacheGroup:
+                type: string
               conditions:
                 items:
                   properties:

--- a/internal/controller/warmup_controller.go
+++ b/internal/controller/warmup_controller.go
@@ -164,6 +164,7 @@ func (o *onceHandler) sync(ctx context.Context, wu *juicefsiov1.WarmUp, cgName s
 	newStatus := o.calculateStatus(ctx, &job)
 	if !reflect.DeepEqual(wu.Status, newStatus) {
 		wu.Status = *newStatus
+		wu.Status.CacheGroup = cgName
 		return utils.IgnoreConflict(o.Status().Update(ctx, wu))
 	}
 


### PR DESCRIPTION
fix: https://github.com/juicedata/juicefs-operator/issues/59