### PR TITLE
fix(sync): improve SSH startup compatibility for RHEL-based image

### DIFF
--- a/pkg/builder/sync_pod.go
+++ b/pkg/builder/sync_pod.go
@@ -42,8 +42,11 @@ READ_ONLY_SSH_KEY_PATH=/root/ssh/
 if [ "$IS_DISTRIBUTED" = "true" ]; then
 	# disable strict host key checking
 	sed -i 's/^#\s*\(StrictHostKeyChecking\s*\).*/\1no/' /etc/ssh/ssh_config
+	sed -i 's/^#\?\s*\(UsePAM\s*\).*/\1no/' /etc/ssh/sshd_config
 	echo "    UserKnownHostsFile /dev/null" >> /etc/ssh/ssh_config
-	service ssh start
+
+	ssh-keygen -A
+	/usr/sbin/sshd
 
 	if [ ! -d "$READ_ONLY_SSH_KEY_PATH" ]; then
 		echo "No ssh key found"


### PR DESCRIPTION
I am using a custom mount pod image based on RHEL 8. 
However, the current script failed for the following reasons. 
This PR fixes these issues while maintaining compatibility with Ubuntu and the current mount pod image. (`juicedata/mount:ce-v1.3.0`)


Changes:

- **Disable PAM (`UsePAM no`)**
  - Latest rhel and ubuntu default to `UsePAM yes`, which can prevent ssh connections.
  - Explicitly disabled PAM to ensure connectivity.
- **Exec sshd using binary instead of service**
  - `service ssh start` fails on RHEL because systemd is not available in the container
  - Changed to execute `/usr/sbin/sshd` directly.
- **Explicit generate host key**
  - In my case, host keys were not generated automatically after installing openssh-server.
  - Added ssh-keygen -A to explicitly ensure that host keys exist at runtime


