### PR TITLE
fix(sync): add security context with SYS_ADMIN and SYS_CHROOT capabilities

### DIFF
--- a/pkg/builder/sync_pod.go
+++ b/pkg/builder/sync_pod.go
@@ -174,6 +174,11 @@ done
 					Image:           s.sc.Spec.Image,
 					ImagePullPolicy: s.sc.Spec.ImagePullPolicy,
 					Resources:       s.getWorkerResources(),
+					SecurityContext: &corev1.SecurityContext{
+						Capabilities: &corev1.Capabilities{
+							Add: []corev1.Capability{"SYS_ADMIN", "SYS_CHROOT"},
+						},
+					},
 					Command: []string{
 						"sh",
 						"-c",


### PR DESCRIPTION
`sync cluster` cannot work in the cri-o because cri-o does not include `SYS_CHROOT` capabilities by default, but it works normally in containerd.


ref: https://github.com/cri-o/cri-o/issues/5116