### PR TITLE
fix(warmup): output mount logs to stdout

### DIFF
--- a/pkg/builder/job.go
+++ b/pkg/builder/job.go
@@ -162,7 +162,7 @@ func (j *JobBuilder) genBaseJob() *batchv1.Job {
 }
 
 var (
-	ignoreMountOpts = []string{"foreground", "cache-size", "free-space-ratio", "group-weight", "cache-dir", "group-backup", "cache-group", "no-sharing"}
+	ignoreMountOpts = []string{"foreground", "cache-size", "free-space-ratio", "group-weight", "cache-dir", "group-backup", "cache-group", "no-sharing", "log", "no-syslog"}
 )
 
 func (j *JobBuilder) getImage() string {
@@ -277,6 +277,8 @@ func (j *JobBuilder) getWarmUpMountInfo() warmUpMountInfo {
 			"cache-group=" + j.cacheGroupName,
 			"no-sharing",
 			"cache-size=0",
+			"log=/dev/stdout",
+			"no-syslog",
 		},
 	}
 


### PR DESCRIPTION
## What changed

- route WarmUp mount logs to `/dev/stdout`
- disable duplicate syslog output
- prevent inherited mount options from overriding the WarmUp log destination

## Why

WarmUp runs `mount.juicefs` in the background before starting the foreground warmup command. The mount client therefore wrote its logs to a file instead of the container standard output, so Kubernetes log collectors could not collect them.

## Impact

Mount client logs are now available through `kubectl logs` and standard Kubernetes logging agents. WarmUp command execution, progress parsing, and Job completion behavior remain unchanged.

## Validation

- `go test ./pkg/...`
- manually verified with Kubernetes v1.35.0, CRI-O 1.34.3, and JuiceFS EE 5.3.5: mount logs appeared in the container log, WarmUp reached 100%, and the Job completed with exit code 0

Fixes #77