### PR TITLE
fix(sync): set worker scp connection timeout

### DIFF
--- a/pkg/builder/sync_pod.go
+++ b/pkg/builder/sync_pod.go
@@ -79,7 +79,7 @@ if [ "$IS_DISTRIBUTED" = "true" ]; then
 	# copy auth files to workers
 	if ls /root/.juicefs/*.conf >/dev/null 2>&1; then
 		for ip in $(echo $WORKER_IPS | sed "s/,/ /g"); do
-			scp -r -o StrictHostKeyChecking=no /root/.juicefs/*.conf root@$ip:/root/.juicefs
+			scp -r -o ConnectTimeout=10 -o StrictHostKeyChecking=no /root/.juicefs/*.conf root@$ip:/root/.juicefs
 		done
 	fi
 fi


### PR DESCRIPTION
## What changed

- Set `ConnectTimeout=10` when the sync manager copies JuiceFS auth files to worker pods with `scp`.

## Why

The worker `scp` command had no explicit connection timeout. If a worker accepted the TCP connection but did not complete the SSH banner or key exchange, the manager could remain blocked until the system TCP keepalive timeout, delaying failure reporting for more than two hours.

## Impact

Distributed sync jobs now fail promptly when a worker SSH connection or initial handshake cannot be established.

## Checks

- `go test ./pkg/builder`